### PR TITLE
Feature: Try exercise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.iml
 .gradle
 /local.properties
-/.idea
+.idea/
 .DS_Store
 /build
 /captures

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,7 @@
 *.iml
 .gradle
 /local.properties
-/.idea/caches
-/.idea/libraries
-/.idea/modules.xml
-/.idea/workspace.xml
-/.idea/navEditor.xml
-/.idea/assetWizardSettings.xml
+/.idea
 .DS_Store
 /build
 /captures

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,13 +4,13 @@ import com.google.protobuf.gradle.protobuf
 import com.google.protobuf.gradle.protoc
 
 plugins {
-    id("com.android.application")
-    id("org.jetbrains.kotlin.android")
-    id("org.jetbrains.kotlin.plugin.serialization")
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.serialization)
 
-    kotlin("kapt")
-    id("com.google.dagger.hilt.android")
-    id("com.google.protobuf")
+    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.hilt.android)
+    alias(libs.plugins.protobuf)
 }
 
 android {
@@ -59,7 +59,7 @@ android {
 // Setup protobuf configuration, generating lite Java and Kotlin classes
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:22.0"
+        artifact = libs.protoc.get().toString()
     }
     generateProtoTasks {
         all().forEach { task ->
@@ -76,30 +76,30 @@ protobuf {
 }
 
 dependencies {
-    implementation("androidx.core:core-ktx:1.9.0")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.5.1")
-    implementation("androidx.activity:activity-compose:1.6.1")
-    implementation("androidx.compose.ui:ui:1.3.3")
-    implementation("androidx.compose.ui:ui-tooling-preview:1.3.3")
-    implementation("androidx.compose.material3:material3:1.0.1")
-    implementation("androidx.datastore:datastore-preferences:1.0.0")
-    implementation("androidx.datastore:datastore:1.0.0")
-    implementation("com.google.dagger:hilt-android:2.44.2")
-    kapt("com.google.dagger:hilt-android-compiler:2.44.2")
-    implementation("com.google.protobuf:protobuf-kotlin-lite:3.21.12")
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.ui.tooling.preview)
+    implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.datastore.preferences)
+    implementation(libs.androidx.datastore)
+    implementation(libs.hilt.android)
+    kapt(libs.hilt.android.compiler)
+    implementation(libs.protobuf.kotlin.lite)
 
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0-RC")
-    implementation("com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:0.8.0")
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.retrofit.converter.kotlinx.serialization)
 
-    implementation("com.squareup.okhttp3:okhttp:4.10.0")
-    implementation("com.squareup.retrofit2:retrofit:2.9.0")
+    implementation(libs.okhttp)
+    implementation(libs.retrofit)
 
-    testImplementation("junit:junit:4.13.2")
-    androidTestImplementation("androidx.test.ext:junit:1.1.5")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
-    androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.3.3")
-    debugImplementation("androidx.compose.ui:ui-tooling:1.3.3")
-    debugImplementation("androidx.compose.ui:ui-test-manifest:1.3.3")
+    testImplementation(libs.junit)
+    androidTestImplementation(libs.androidx.test.ext.junit)
+    androidTestImplementation(libs.androidx.test.espresso.core)
+    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+    debugImplementation(libs.androidx.compose.ui.tooling)
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
 }
 
 kapt {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 
 android {
     namespace = "jp.speakbuddy.edisonandroidexercise"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "jp.speakbuddy.edisonandroidexercise"
@@ -84,6 +84,7 @@ dependencies {
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.datastore)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.hilt.android)
     kapt(libs.hilt.android.compiler)
     implementation(libs.protobuf.kotlin.lite)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.android.junit5)
 
     alias(libs.plugins.kotlin.kapt)
     alias(libs.plugins.hilt.android)
@@ -95,10 +96,18 @@ dependencies {
     implementation(libs.okhttp)
     implementation(libs.retrofit)
 
+    testImplementation(libs.coroutines.test)
+    testImplementation(libs.kotst.assertions)
+    testImplementation(libs.mockk.android)
+    testImplementation(libs.turbine)
     testImplementation(libs.junit)
+    testImplementation(libs.junit.jupiter.api)
+    testRuntimeOnly(libs.junit.jupiter.engine)
+
     androidTestImplementation(libs.androidx.test.ext.junit)
     androidTestImplementation(libs.androidx.test.espresso.core)
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
 }

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/EdisonAndroidExerciseApplication.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/EdisonAndroidExerciseApplication.kt
@@ -1,5 +1,7 @@
 package jp.speakbuddy.edisonandroidexercise
 
 import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
 
+@HiltAndroidApp
 class EdisonAndroidExerciseApplication : Application()

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/MainActivity.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/MainActivity.kt
@@ -7,19 +7,19 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
+import dagger.hilt.android.AndroidEntryPoint
 import jp.speakbuddy.edisonandroidexercise.ui.fact.FactScreen
 import jp.speakbuddy.edisonandroidexercise.ui.fact.FactViewModel
 import jp.speakbuddy.edisonandroidexercise.ui.theme.EdisonAndroidExerciseTheme
 
+@AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            EdisonAndroidExerciseTheme {
-                // A surface container using the 'background' color from the theme
+            EdisonAndroidExerciseTheme { // A surface container using the 'background' color from the theme
                 Surface(
-                    modifier = Modifier.fillMaxSize(),
-                    color = MaterialTheme.colorScheme.background
+                    modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background
                 ) {
                     FactScreen(viewModel = FactViewModel())
                 }

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/MainActivity.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/MainActivity.kt
@@ -9,7 +9,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
 import dagger.hilt.android.AndroidEntryPoint
 import jp.speakbuddy.edisonandroidexercise.ui.fact.FactScreen
-import jp.speakbuddy.edisonandroidexercise.ui.fact.FactViewModel
 import jp.speakbuddy.edisonandroidexercise.ui.theme.EdisonAndroidExerciseTheme
 
 @AndroidEntryPoint
@@ -21,7 +20,7 @@ class MainActivity : ComponentActivity() {
                 Surface(
                     modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background
                 ) {
-                    FactScreen(viewModel = FactViewModel())
+                    FactScreen()
                 }
             }
         }

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/di/DataStoreModule.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/di/DataStoreModule.kt
@@ -1,0 +1,25 @@
+package jp.speakbuddy.edisonandroidexercise.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import jp.speakbuddy.edisonandroidexercise.FactStore
+import jp.speakbuddy.edisonandroidexercise.storage.factDataStore
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DataStoreModule {
+
+    @Provides
+    @Singleton
+    fun provideDataStore(
+        @ApplicationContext context: Context,
+    ): DataStore<FactStore> {
+        return context.factDataStore
+    }
+}

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/di/NetworkModule.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/di/NetworkModule.kt
@@ -1,0 +1,23 @@
+package jp.speakbuddy.edisonandroidexercise.di
+
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import jp.speakbuddy.edisonandroidexercise.network.FactService
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import retrofit2.Retrofit
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkModule {
+
+    @Provides
+    fun provideRepositoryService(): Retrofit =
+        Retrofit.Builder().baseUrl("https://catfact.ninja/").addConverterFactory(Json.asConverterFactory("application/json".toMediaType())).build()
+
+    @Provides
+    fun provideFactService(retrofit: Retrofit): FactService = retrofit.create(FactService::class.java)
+}

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/di/NetworkModule.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/di/NetworkModule.kt
@@ -15,7 +15,7 @@ import retrofit2.Retrofit
 object NetworkModule {
 
     @Provides
-    fun provideRepositoryService(): Retrofit =
+    fun provideRetrofit(): Retrofit =
         Retrofit.Builder().baseUrl("https://catfact.ninja/").addConverterFactory(Json.asConverterFactory("application/json".toMediaType())).build()
 
     @Provides

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/network/FactNetworkDataSource.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/network/FactNetworkDataSource.kt
@@ -1,0 +1,10 @@
+package jp.speakbuddy.edisonandroidexercise.network
+
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class FactNetworkDataSource @Inject constructor(
+    private val factService: FactService,
+) {
+    fun fetchFact() = flow { emit(factService.getFact()) }
+}

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/network/FactService.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/network/FactService.kt
@@ -1,10 +1,6 @@
 package jp.speakbuddy.edisonandroidexercise.network
 
-import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
-import okhttp3.MediaType.Companion.toMediaType
-import retrofit2.Retrofit
 import retrofit2.http.GET
 
 interface FactService {
@@ -15,14 +11,6 @@ interface FactService {
 @Serializable
 data class FactResponse(
     val fact: String,
-    val length: Int
+    val length: Int,
 )
 
-object FactServiceProvider {
-    fun provide(): FactService =
-        Retrofit.Builder()
-            .baseUrl("https://catfact.ninja/")
-            .addConverterFactory(Json.asConverterFactory("application/json".toMediaType()))
-            .build()
-            .create(FactService::class.java)
-}

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/repository/FactRepository.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/repository/FactRepository.kt
@@ -8,13 +8,14 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
+// MEMO: 今回は interface を切らずに mockk を利用することでテスタブルにした。ここはチームの方針でテスト時にFake実装に差し替えるなら interface を切る
 class FactRepository @Inject constructor(
     private val factNetworkDataSource: FactNetworkDataSource,
     private val factLocalDataSource: FactLocalDataSource,
 ) {
     fun fetchFact() = factNetworkDataSource.fetchFact().onEach {
         factLocalDataSource.saveFact(it)
-    }.catch {
+    }.catch { // MEMO: 本来は Room とかで複数件保存しておいてランダムで取得するような仕組みが必要
         val fact = factLocalDataSource.factList.first()
         emit(
             FactResponse(

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/repository/FactRepository.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/repository/FactRepository.kt
@@ -5,7 +5,6 @@ import jp.speakbuddy.edisonandroidexercise.network.FactResponse
 import jp.speakbuddy.edisonandroidexercise.storage.FactLocalDataSource
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
@@ -15,8 +14,6 @@ class FactRepository @Inject constructor(
 ) {
     fun fetchFact() = factNetworkDataSource.fetchFact().onEach {
         factLocalDataSource.saveFact(it)
-    }.map {
-        it
     }.catch {
         val fact = factLocalDataSource.factList.first()
         emit(

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/repository/FactRepository.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/repository/FactRepository.kt
@@ -1,0 +1,10 @@
+package jp.speakbuddy.edisonandroidexercise.repository
+
+import jp.speakbuddy.edisonandroidexercise.network.FactService
+import javax.inject.Inject
+
+class FactRepository @Inject constructor(
+    private val factService: FactService,
+) {
+    suspend fun fetchFact() = factService.getFact()
+}

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/storage/FactLocalDataSource.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/storage/FactLocalDataSource.kt
@@ -1,0 +1,19 @@
+package jp.speakbuddy.edisonandroidexercise.storage
+
+import androidx.datastore.core.DataStore
+import jp.speakbuddy.edisonandroidexercise.FactStore
+import jp.speakbuddy.edisonandroidexercise.network.FactResponse
+import javax.inject.Inject
+
+class FactLocalDataSource @Inject constructor(
+    private val dataStore: DataStore<FactStore>,
+) {
+
+    val factList = dataStore.data
+
+    suspend fun saveFact(fact: FactResponse) {
+        dataStore.updateData { current ->
+            current.toBuilder().setFact(fact.fact).setLength(fact.length).build()
+        }
+    }
+}

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/storage/FactStoreSerializer.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/storage/FactStoreSerializer.kt
@@ -1,0 +1,33 @@
+package jp.speakbuddy.edisonandroidexercise.storage
+
+import android.content.Context
+import androidx.datastore.core.CorruptionException
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.Serializer
+import androidx.datastore.dataStore
+import androidx.datastore.preferences.protobuf.InvalidProtocolBufferException
+import jp.speakbuddy.edisonandroidexercise.FactStore
+import java.io.InputStream
+import java.io.OutputStream
+
+object FactStoreSerializer : Serializer<FactStore> {
+
+    override val defaultValue: FactStore
+        get() = FactStore.getDefaultInstance()
+
+    override suspend fun readFrom(input: InputStream): FactStore {
+        try {
+            return FactStore.parseFrom(input)
+        } catch (exception: InvalidProtocolBufferException) {
+            throw CorruptionException("Cannot read proto.", exception)
+        }
+    }
+
+    override suspend fun writeTo(t: FactStore, output: OutputStream) {
+        t.writeTo(output)
+    }
+}
+
+val Context.factDataStore: DataStore<FactStore> by dataStore(
+    fileName = "fact_store.pb", serializer = FactStoreSerializer
+)

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactScreen.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactScreen.kt
@@ -6,14 +6,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -22,36 +19,38 @@ import jp.speakbuddy.edisonandroidexercise.ui.theme.EdisonAndroidExerciseTheme
 
 @Composable
 fun FactScreen(
-    viewModel: FactViewModel
+    viewModel: FactViewModel,
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    FactContent(uiState = uiState, onUpdateFactClicked = { viewModel.updateFact() })
+}
+
+@Composable
+fun FactContent(
+    uiState: FactUiState,
+    onUpdateFactClicked: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
             .padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(
-            space = 16.dp,
-            alignment = Alignment.CenterVertically
+            space = 16.dp, alignment = Alignment.CenterVertically
         )
     ) {
-        var fact by remember { mutableStateOf("") }
-
         Text(
-            text = "Fact",
-            style = MaterialTheme.typography.titleLarge
+            text = "Fact", style = MaterialTheme.typography.titleLarge
         )
 
         Text(
-            text = fact,
-            style = MaterialTheme.typography.bodyLarge
+            text = uiState.fact, style = MaterialTheme.typography.bodyLarge
         )
 
-        val onClick = {
-            fact = viewModel.updateFact { print("done") }
-        }
-
-        Button(onClick = onClick) {
+        Button(onClick = onUpdateFactClicked) {
             Text(text = "Update fact")
         }
     }
@@ -61,6 +60,6 @@ fun FactScreen(
 @Composable
 private fun FactScreenPreview() {
     EdisonAndroidExerciseTheme {
-        FactScreen(viewModel = FactViewModel())
+        FactContent(uiState = FactUiState(fact = "Cats are cute"), onUpdateFactClicked = {})
     }
 }

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactScreen.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactScreen.kt
@@ -19,7 +19,7 @@ import jp.speakbuddy.edisonandroidexercise.ui.theme.EdisonAndroidExerciseTheme
 
 @Composable
 fun FactScreen(
-    viewModel: FactViewModel,
+    viewModel: FactViewModel = androidx.lifecycle.viewmodel.compose.viewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
 

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactScreen.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import jp.speakbuddy.edisonandroidexercise.network.FactResponse
 import jp.speakbuddy.edisonandroidexercise.ui.theme.EdisonAndroidExerciseTheme
 
 @Composable
@@ -42,16 +43,48 @@ fun FactContent(
             space = 16.dp, alignment = Alignment.CenterVertically
         )
     ) {
+        Title(containsCats = uiState.containsCats)
+        Body(fact = uiState.fact, isLongFact = uiState.isLongFact)
+        Button(onClick = onUpdateFactClicked) {
+            Text(text = "Update fact")
+        }
+    }
+}
+
+@Composable
+fun Title(
+    containsCats: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = modifier) {
         Text(
             text = "Fact", style = MaterialTheme.typography.titleLarge
         )
+        if (containsCats) {
+            Text(text = "Multiple cats!!", style = MaterialTheme.typography.titleMedium)
+        }
+    }
+}
 
+@Composable
+fun Body(
+    fact: FactResponse,
+    isLongFact: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
         Text(
-            text = uiState.fact, style = MaterialTheme.typography.bodyLarge
+            text = fact.fact, style = MaterialTheme.typography.bodyLarge
         )
 
-        Button(onClick = onUpdateFactClicked) {
-            Text(text = "Update fact")
+        if (isLongFact) {
+            Text(
+                text = "length: ${fact.length}",
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier
+                    .padding(end = 16.dp)
+                    .align(Alignment.End)
+            )
         }
     }
 }
@@ -59,7 +92,8 @@ fun FactContent(
 @Preview
 @Composable
 private fun FactScreenPreview() {
+    val label = "Cat is cute"
     EdisonAndroidExerciseTheme {
-        FactContent(uiState = FactUiState(fact = "Cats are cute"), onUpdateFactClicked = {})
+        FactContent(uiState = FactUiState(fact = FactResponse(label, label.length)), onUpdateFactClicked = {})
     }
 }

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactScreen.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactScreen.kt
@@ -13,10 +13,12 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import jp.speakbuddy.edisonandroidexercise.network.FactResponse
 import jp.speakbuddy.edisonandroidexercise.ui.theme.EdisonAndroidExerciseTheme
+import jp.speakbuddy.edisonandroidexercise.ui.theme.OrientationPreviews
 
 @Composable
 fun FactScreen(
@@ -89,11 +91,24 @@ fun Body(
     }
 }
 
-@Preview
+class UserProfileProvider : PreviewParameterProvider<FactUiState> {
+    override val values = sequenceOf(
+        FactUiState(fact = FactResponse("Cats lap liquid from the underside of their tongue, not from the top.", 69)),
+        FactUiState(
+            fact = FactResponse(
+                "There is a species of cat smaller than the average housecat. It is native to Africa and it is the Black-footed cat (Felis nigripes). Its top weight is 5.5 pounds.",
+                162
+            ), error = null
+        ),
+    )
+}
+
+@OrientationPreviews
 @Composable
-private fun FactScreenPreview() {
-    val label = "Cat is cute"
+private fun FactScreenPreview(
+    @PreviewParameter(UserProfileProvider::class) uiState: FactUiState,
+) {
     EdisonAndroidExerciseTheme {
-        FactContent(uiState = FactUiState(fact = FactResponse(label, label.length)), onUpdateFactClicked = {})
+        FactContent(uiState = uiState, onUpdateFactClicked = {})
     }
 }

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactViewModel.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactViewModel.kt
@@ -3,7 +3,7 @@ package jp.speakbuddy.edisonandroidexercise.ui.fact
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import jp.speakbuddy.edisonandroidexercise.network.FactServiceProvider
+import jp.speakbuddy.edisonandroidexercise.repository.FactRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -11,14 +11,16 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class FactViewModel @Inject constructor() : ViewModel() {
+class FactViewModel @Inject constructor(
+    private val factRepository: FactRepository,
+) : ViewModel() {
 
     private val _uiState = MutableStateFlow(FactUiState.initial)
     val uiState: StateFlow<FactUiState> = _uiState.asStateFlow()
 
     fun updateFact() {
         viewModelScope.launch {
-            val fact = FactServiceProvider.provide().getFact().fact
+            val fact = factRepository.fetchFact().fact
             _uiState.value = FactUiState(fact = fact)
         }
     }

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactViewModel.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactViewModel.kt
@@ -1,16 +1,18 @@
 package jp.speakbuddy.edisonandroidexercise.ui.fact
 
 import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
 import jp.speakbuddy.edisonandroidexercise.network.FactServiceProvider
 import kotlinx.coroutines.runBlocking
+import javax.inject.Inject
 
-class FactViewModel : ViewModel() {
-    fun updateFact(completion: () -> Unit): String =
-        runBlocking {
-            try {
-                FactServiceProvider.provide().getFact().fact
-            } catch (e: Throwable) {
-                "something went wrong. error = ${e.message}"
-            }.also { completion() }
-        }
+@HiltViewModel
+class FactViewModel @Inject constructor() : ViewModel() {
+    fun updateFact(completion: () -> Unit): String = runBlocking {
+        try {
+            FactServiceProvider.provide().getFact().fact
+        } catch (e: Throwable) {
+            "something went wrong. error = ${e.message}"
+        }.also { completion() }
+    }
 }

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactViewModel.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactViewModel.kt
@@ -3,6 +3,7 @@ package jp.speakbuddy.edisonandroidexercise.ui.fact
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import jp.speakbuddy.edisonandroidexercise.network.FactResponse
 import jp.speakbuddy.edisonandroidexercise.repository.FactRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -24,7 +25,7 @@ class FactViewModel @Inject constructor(
     fun updateFact() {
         factRepository.fetchFact().onEach { fact ->
             _uiState.update {
-                it.copy(fact = fact.fact, error = null)
+                it.copy(fact = fact, error = null)
             }
         }.catch {
             _uiState.update {
@@ -35,11 +36,14 @@ class FactViewModel @Inject constructor(
 }
 
 data class FactUiState(
-    val fact: String,
+    val fact: FactResponse,
     val error: Throwable? = null,
 ) {
     companion object {
-        val initial = FactUiState(fact = "")
+        val initial = FactUiState(fact = FactResponse("", 0))
     }
+
+    val isLongFact = fact.length >= 100
+    val containsCats = fact.fact.contains("cats", ignoreCase = true)
 }
 

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactViewModel.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactViewModel.kt
@@ -43,6 +43,7 @@ data class FactUiState(
         val initial = FactUiState(fact = FactResponse("", 0))
     }
 
+    // MEMO: モデルに含めるロジックか悩んだがこの画面特有のロジックであると判断し、ViewModel に持たせた
     val isLongFact = fact.length >= 100
     val containsCats = fact.fact.contains("cats", ignoreCase = true)
 }

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactViewModel.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactViewModel.kt
@@ -1,18 +1,34 @@
 package jp.speakbuddy.edisonandroidexercise.ui.fact
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jp.speakbuddy.edisonandroidexercise.network.FactServiceProvider
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class FactViewModel @Inject constructor() : ViewModel() {
-    fun updateFact(completion: () -> Unit): String = runBlocking {
-        try {
-            FactServiceProvider.provide().getFact().fact
-        } catch (e: Throwable) {
-            "something went wrong. error = ${e.message}"
-        }.also { completion() }
+
+    private val _uiState = MutableStateFlow(FactUiState.initial)
+    val uiState: StateFlow<FactUiState> = _uiState.asStateFlow()
+
+    fun updateFact() {
+        viewModelScope.launch {
+            val fact = FactServiceProvider.provide().getFact().fact
+            _uiState.value = FactUiState(fact = fact)
+        }
     }
 }
+
+data class FactUiState(
+    val fact: String,
+) {
+    companion object {
+        val initial = FactUiState(fact = "")
+    }
+}
+

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactViewModel.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactViewModel.kt
@@ -27,9 +27,9 @@ class FactViewModel @Inject constructor(
             _uiState.update {
                 it.copy(fact = fact, error = null)
             }
-        }.catch {
+        }.catch { throwable ->
             _uiState.update {
-                it.copy(error = it.error)
+                it.copy(error = throwable)
             }
         }.launchIn(viewModelScope)
     }

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/theme/PreviewAnnotation.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/theme/PreviewAnnotation.kt
@@ -1,0 +1,9 @@
+package jp.speakbuddy.edisonandroidexercise.ui.theme
+
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+
+
+@Preview(name = "Landscape Mode", showBackground = true, device = Devices.NEXUS_10, widthDp = 640)
+@Preview(name = "Portrait Mode", showBackground = true, device = Devices.PIXEL_4)
+annotation class OrientationPreviews

--- a/app/src/main/proto/fact_store.proto
+++ b/app/src/main/proto/fact_store.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+option java_package = "jp.speakbuddy.edisonandroidexercise";
+option java_multiple_files = true;
+
+message FactStore {
+  string fact = 1;
+  int32 length = 2;
+}

--- a/app/src/test/java/jp/speakbuddy/edisonandroidexercise/repository/FactRepositoryTest.kt
+++ b/app/src/test/java/jp/speakbuddy/edisonandroidexercise/repository/FactRepositoryTest.kt
@@ -1,0 +1,79 @@
+package jp.speakbuddy.edisonandroidexercise.repository
+
+import app.cash.turbine.test
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import jp.speakbuddy.edisonandroidexercise.FactStore
+import jp.speakbuddy.edisonandroidexercise.network.FactNetworkDataSource
+import jp.speakbuddy.edisonandroidexercise.network.FactResponse
+import jp.speakbuddy.edisonandroidexercise.storage.FactLocalDataSource
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.io.IOException
+
+class FactRepositoryTest {
+
+    private fun createFactRepository(
+        factNetworkDataSource: FactNetworkDataSource = mockk(),
+        factLocalDataSource: FactLocalDataSource = mockk(),
+    ): FactRepository {
+        return FactRepository(factNetworkDataSource, factLocalDataSource)
+    }
+
+    @Test
+    fun リモートAPIからFactを取得する() = runTest {
+        val mockFactNetworkDataSource = mockk<FactNetworkDataSource>() {
+            every { fetchFact() } returns flowOf(FactResponse("Fact", 4))
+        }
+        val mockFactLocalDataSource = mockk<FactLocalDataSource>() {
+            coEvery { saveFact(any()) } just runs
+        }
+        val repository = createFactRepository(factNetworkDataSource = mockFactNetworkDataSource, factLocalDataSource = mockFactLocalDataSource)
+
+        repository.fetchFact().test {
+            val result = awaitItem()
+            result.fact shouldBe "Fact"
+            result.length shouldBe 4
+
+            coVerify(exactly = 1) {
+                mockFactLocalDataSource.saveFact(FactResponse("Fact", 4))
+            }
+
+            coVerify(exactly = 0) {
+                mockFactLocalDataSource.factList
+            }
+
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun リモートAPIからFactの取得に失敗した場合はローカルから取得する() = runTest {
+        val mockFactNetworkDataSource = mockk<FactNetworkDataSource>() {
+            every { fetchFact() } returns flow { throw IOException() }
+        }
+        val mockFactLocalDataSource = mockk<FactLocalDataSource>() {
+            coEvery { saveFact(any()) } just runs
+            coEvery { factList } returns flowOf(mockk<FactStore> {
+                every { fact } returns "Local Fact"
+                every { length } returns 5
+            })
+        }
+        val repository = createFactRepository(factNetworkDataSource = mockFactNetworkDataSource, factLocalDataSource = mockFactLocalDataSource)
+
+        repository.fetchFact().test {
+            val result = awaitItem()
+            result.fact shouldBe "Local Fact"
+            result.length shouldBe 5
+
+            awaitComplete()
+        }
+    }
+}

--- a/app/src/test/java/jp/speakbuddy/edisonandroidexercise/ui/FactViewModelTest.kt
+++ b/app/src/test/java/jp/speakbuddy/edisonandroidexercise/ui/FactViewModelTest.kt
@@ -1,11 +1,131 @@
 package jp.speakbuddy.edisonandroidexercise.ui
 
-import org.junit.Test
+import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import jp.speakbuddy.edisonandroidexercise.network.FactResponse
+import jp.speakbuddy.edisonandroidexercise.repository.FactRepository
+import jp.speakbuddy.edisonandroidexercise.ui.fact.FactViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
 
 class FactViewModelTest {
 
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(Dispatchers.Unconfined)
+    }
 
-    @Test
-    fun updateFact() {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createFactViewModel(
+        factRepository: FactRepository = mockk(),
+    ): FactViewModel {
+        return FactViewModel(factRepository)
+    }
+
+    @TestFactory
+    fun データ取得結果をUIに反映できること(): List<DynamicTest> {
+        data class TestCase(
+            val response: Flow<FactResponse>,
+            val assertion: (FactViewModel) -> Unit,
+        )
+
+        val error = RuntimeException()
+        val testCases = listOf(
+            TestCase(
+                response = flowOf(FactResponse(fact = "Fact1", length = 5)),
+                assertion = { viewModel ->
+                    viewModel.uiState.value.fact shouldBeEqual FactResponse(fact = "Fact1", length = 5)
+                    viewModel.uiState.value.error shouldBe null
+                },
+            ),
+            TestCase(
+                response = flow { throw error },
+                assertion = { viewModel ->
+                    viewModel.uiState.value.error shouldBe error
+                },
+            ),
+        )
+
+        return testCases.map { testCase ->
+            DynamicTest.dynamicTest(testCase.toString()) { // Arrange
+                val mockFactRepository = mockk<FactRepository>() {
+                    every { fetchFact() } returns testCase.response
+                }
+                val viewModel = createFactViewModel(factRepository = mockFactRepository)
+
+                viewModel.updateFact()
+
+                testCase.assertion(viewModel)
+            }
+        }
+    }
+
+    @TestFactory
+    fun データ取得結果に応じたUI状態を取得できること(): List<DynamicTest> {
+        data class TestCase(
+            val response: FactResponse,
+            val assertion: (FactViewModel) -> Unit,
+        )
+
+        val testCases = listOf(
+            TestCase(
+                response = FactResponse(fact = "Fact1", length = 5),
+                assertion = { viewModel ->
+                    viewModel.uiState.value.isLongFact shouldBe false
+                    viewModel.uiState.value.containsCats shouldBe false
+                },
+            ),
+            TestCase(
+                response = FactResponse(fact = "Fact1", length = 100),
+                assertion = { viewModel ->
+                    viewModel.uiState.value.isLongFact shouldBe true
+                    viewModel.uiState.value.containsCats shouldBe false
+                },
+            ),
+            TestCase(
+                response = FactResponse(fact = "Fact1 with cats", length = 5),
+                assertion = { viewModel ->
+                    viewModel.uiState.value.isLongFact shouldBe false
+                    viewModel.uiState.value.containsCats shouldBe true
+                },
+            ),
+            TestCase(
+                response = FactResponse(fact = "Fact1 with Cats", length = 5),
+                assertion = { viewModel ->
+                    viewModel.uiState.value.isLongFact shouldBe false
+                    viewModel.uiState.value.containsCats shouldBe true
+                },
+            ),
+        )
+
+        return testCases.map { testCase ->
+            DynamicTest.dynamicTest(testCase.toString()) { // Arrange
+                val mockFactRepository = mockk<FactRepository>() {
+                    every { fetchFact() } returns flowOf(testCase.response)
+                }
+                val viewModel = createFactViewModel(factRepository = mockFactRepository)
+
+                viewModel.updateFact()
+
+                testCase.assertion(viewModel)
+            }
+        }
     }
 }

--- a/app/src/test/java/jp/speakbuddy/edisonandroidexercise/ui/FactViewModelTest.kt
+++ b/app/src/test/java/jp/speakbuddy/edisonandroidexercise/ui/FactViewModelTest.kt
@@ -1,21 +1,11 @@
 package jp.speakbuddy.edisonandroidexercise.ui
 
-import jp.speakbuddy.edisonandroidexercise.ui.fact.FactViewModel
 import org.junit.Test
 
 class FactViewModelTest {
 
-    private val viewModel = FactViewModel()
 
     @Test
     fun updateFact() {
-        var loading = true
-        val initialFact = "initial"
-        var fact = initialFact
-
-        fact = viewModel.updateFact { loading = false }
-
-        assert(!loading)
-        assert(fact != initialFact)
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,11 @@
 plugins {
-    id("com.android.application") version "7.4.1" apply false
-    id("com.android.library") version "7.4.1" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.10" apply false
-    id("com.google.dagger.hilt.android") version "2.44.2" apply false
-    id("com.google.protobuf") version "0.8.19" apply false
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.hilt.android) apply false
+    alias(libs.plugins.protobuf) apply false
+    alias(libs.plugins.kotlin.kapt) apply false
 
-    kotlin("jvm") version "1.8.10"
-    kotlin("plugin.serialization") version "1.8.10"
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.hilt.android) apply false
     alias(libs.plugins.protobuf) apply false
     alias(libs.plugins.kotlin.kapt) apply false
+    alias(libs.plugins.android.junit5) apply false
 
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.serialization)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ androidxActivity = "1.6.1"
 androidxCompose = "1.3.3"
 androidxComposeMaterial3 = "1.0.1"
 androidxDatastore = "1.0.0"
+androidxViewModelCompose = "2.7.0"
 hilt = "2.44.2"
 protoc = "22.0"
 protobuf = "3.21.12"
@@ -28,6 +29,7 @@ androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling
 androidx-compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "androidxComposeMaterial3" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "androidxDatastore" }
 androidx-datastore = { module = "androidx.datastore:datastore", version.ref = "androidxDatastore" }
+androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidxViewModelCompose" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
 protoc = { module = "com.google.protobuf:protoc", version.ref = "protoc" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,54 @@
+[versions]
+androidGradlePlugin = "7.4.1"
+kotlin = "1.8.10"
+protobufPlugin = "0.8.19"
+androidxCore = "1.9.0"
+androidxLifecycle = "2.5.1"
+androidxActivity = "1.6.1"
+androidxCompose = "1.3.3"
+androidxComposeMaterial3 = "1.0.1"
+androidxDatastore = "1.0.0"
+hilt = "2.44.2"
+protoc = "22.0"
+protobuf = "3.21.12"
+kotlinxSerialization = "1.5.0-RC"
+retrofitKotlinxSerializationConverter = "0.8.0"
+okhttp = "4.10.0"
+retrofit = "2.9.0"
+junit = "4.13.2"
+androidxTestExt = "1.1.5"
+androidxTestEspresso = "3.5.1"
+
+[libraries]
+androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
+androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidxLifecycle" }
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidxActivity" }
+androidx-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "androidxCompose" }
+androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "androidxCompose" }
+androidx-compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "androidxComposeMaterial3" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "androidxDatastore" }
+androidx-datastore = { module = "androidx.datastore:datastore", version.ref = "androidxDatastore" }
+hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
+hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
+protoc = { module = "com.google.protobuf:protoc", version.ref = "protoc" }
+protobuf-kotlin-lite = { module = "com.google.protobuf:protobuf-kotlin-lite", version.ref = "protobuf" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
+retrofit-converter-kotlinx-serialization = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "retrofitKotlinxSerializationConverter" }
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
+junit = { module = "junit:junit", version.ref = "junit" }
+androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidxTestExt" }
+androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidxTestEspresso" }
+androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "androidxCompose" }
+androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "androidxCompose" }
+androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "androidxCompose" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
+android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+protobuf = { id = "com.google.protobuf", version.ref = "protobufPlugin" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,7 @@ androidx-datastore = { module = "androidx.datastore:datastore", version.ref = "a
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidxViewModelCompose" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
-protoc = { module = "com.google.protobuf:protoc", version.ref = "protoc" }
+protoc = { module = "com.google.protobuf:protoc", version.ref = "protobuf" }
 protobuf-kotlin-lite = { module = "com.google.protobuf:protobuf-kotlin-lite", version.ref = "protobuf" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 retrofit-converter-kotlinx-serialization = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "retrofitKotlinxSerializationConverter" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,14 +9,20 @@ androidxCompose = "1.3.3"
 androidxComposeMaterial3 = "1.0.1"
 androidxDatastore = "1.0.0"
 androidxViewModelCompose = "2.7.0"
+coroutines = "1.8.0"
 hilt = "2.44.2"
+kotest = "5.8.1"
+mockk = "1.13.10"
 protoc = "22.0"
 protobuf = "3.21.12"
 kotlinxSerialization = "1.5.0-RC"
 retrofitKotlinxSerializationConverter = "0.8.0"
 okhttp = "4.10.0"
 retrofit = "2.9.0"
+turbine = "1.1.0"
 junit = "4.13.2"
+androidJunit5Plugin = "1.10.0.0"
+junitJupiter = "5.8.2"
 androidxTestExt = "1.1.5"
 androidxTestEspresso = "3.5.1"
 
@@ -30,15 +36,21 @@ androidx-compose-material3 = { module = "androidx.compose.material3:material3", 
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "androidxDatastore" }
 androidx-datastore = { module = "androidx.datastore:datastore", version.ref = "androidxDatastore" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidxViewModelCompose" }
+coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
+kotst-assertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
+mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockk" }
 protoc = { module = "com.google.protobuf:protoc", version.ref = "protobuf" }
 protobuf-kotlin-lite = { module = "com.google.protobuf:protobuf-kotlin-lite", version.ref = "protobuf" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 retrofit-converter-kotlinx-serialization = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "retrofitKotlinxSerializationConverter" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
+turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 junit = { module = "junit:junit", version.ref = "junit" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junitJupiter" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junitJupiter" }
 androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidxTestExt" }
 androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidxTestEspresso" }
 androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "androidxCompose" }
@@ -48,6 +60,7 @@ androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-mani
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
+android-junit5 = { id = "de.mannodermaus.android-junit5", version.ref = "androidJunit5Plugin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 protobuf = { id = "com.google.protobuf", version.ref = "protobufPlugin" }


### PR DESCRIPTION
一度誤ってfork元RepositoryにPRを挙げてしまい申し訳ございませんでした 🙏 

## やったこと
### TODO
- [x] Access data via `Data layer`
- [x] Add local data source using [Jetpack DataStore](https://developer.android.com/topic/libraries/architecture/datastore)
- [x] Add dependency injection by `Hilt`
- [x] Show the `length` from the api response below the `fact` content *only when*
  the `length` is greater than 100
- [x] Show the text "Multiple cats!" when the `fact` contains the word `cats`
  - No context check is required, simply finding the worked `cats` is fine
- [x] Make the UI state immutable as much as possible
- [x] Add unit or UI tests depending on your code
### Optional
- [ ] (Design) Add the `Top app bar` and update the design as you want 🏰
- [x] (Testing) Add [JUnit5](https://github.com/mannodermaus/android-junit5) and `fake` or `mockk`
- [x] (Gradle) Add a `version catalog` 📗
- [ ] (Future growth) `Modularize` the app ✌🏻
- [ ] (Future growth) Add `Domain layer` 🚴‍️
### それ以外
- 複数画面サイズのPreviewを生成するカスタムPreviewAnnotationの追加した
- [Turbine](https://github.com/cashapp/turbine)によるFlow関連のテストを簡単に追加できるようにした

## 時間があればやりたかったこと
- DataSourceのUnitテスト追加 
- Loading/Error UIの追加
- Roomによるオフライン時の対応
- コーディングフォーマットの追加 (.idea/codeStyleSettings.xml)

## 工夫したこと
- UIをコンポーネント単位に切り出した (プロジェクトではデザインシステム等に則る)
``` kt
        Title(containsCats = uiState.containsCats)
        Body(fact = uiState.fact, isLongFact = uiState.isLongFact)
        Button(onClick = onUpdateFactClicked) {
            Text(text = "Update fact")
        }
```

- JUnit5 x DynamicTest を導入し、複数パラメータによるテスト実行を可能に
``` kt
return testCases.map { testCase ->
            DynamicTest.dynamicTest(testCase.toString()) {
```

## スクリーンショット等
|画面| Android Studio Preview|
|-|-|
|![Screenshot_20240406_191141](https://github.com/apparray/edison_android_exercise/assets/16508442/793e27d2-35b6-4f9e-82d1-824d64c73a50)|![スクリーンショット 2024-04-06 19 04 54](https://github.com/apparray/edison_android_exercise/assets/16508442/c608188a-761c-4e9f-890d-0ad8e4a58e0c)|

**動作の様子**

https://github.com/apparray/edison_android_exercise/assets/16508442/6436f0c6-4f04-4037-9322-0140a68f73f9


